### PR TITLE
fix: catch all top level falsy values correctly

### DIFF
--- a/packages/aspida/src/index.ts
+++ b/packages/aspida/src/index.ts
@@ -90,7 +90,7 @@ export const optionToRequest = (
   option?: AspidaParams,
   type?: RequestType
 ): AspidaRequest | undefined => {
-  if (!option?.body) return option
+  if (option?.body === undefined) return option
 
   let httpBody
   const headers: BasicHeaders = {}


### PR DESCRIPTION
## Types of changes

What kind of change does this PR introduce? (check at least one)

<!-- Update "[ ]" to "[x]" to check a box. -->

- [ ] Breaking change
- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

<!-- link to a relevant issue. -->

Issue Number: N/A

<!--- Describe your changes in detail. -->
`reqBody: boolean` で `{body: false}` などを送ったとき、HTTPリクエストの body が空になってしまいます。 fastify は長さ 0 を null と見るので null のときだけうまくいっているように見えます。トップに値があるだけ、というパターンもただしい JSON の値なのでちゃんと送信されるようにしたほうがいいかな…と。

When sending `{body: false}` as the scheme looks like `reqBody: boolean`, body will be empty. Fastify treats length 0 as null, but it should be sent with JSON encoding properly. Please note that only top values are also valid JSON.