### PR TITLE
fix: specify dataToURLString for paramsSerializer of axios

### DIFF
--- a/packages/aspida-axios/src/index.ts
+++ b/packages/aspida-axios/src/index.ts
@@ -1,4 +1,11 @@
-import { AspidaClient, AspidaParams, HttpMethod, optionToRequest, RequestType } from 'aspida'
+import {
+  AspidaClient,
+  AspidaParams,
+  dataToURLString,
+  HttpMethod,
+  optionToRequest,
+  RequestType
+} from 'aspida'
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
 
 export default (
@@ -16,6 +23,7 @@ export default (
     const send = (responseType?: 'arraybuffer' | 'blob' | 'json' | 'text') => async () => {
       const request = optionToRequest(params, type)
       const res = await client.request({
+        paramsSerializer: params => dataToURLString(params),
         ...config,
         url,
         baseURL,


### PR DESCRIPTION
**BREAKING CHANGE**

## Types of changes

- [x] Bug fixes
  - resolves #751 
- [ ] Features
  - resolves #<!-- Please add issue number -->
- [ ] Maintenance
- [ ] Documentation

## Changes

## Additional context

## Community note

<!-- Please keep this section. -->

Please upvote with reacting as :+1: to express your agreement.